### PR TITLE
Allow user supplied string:string data to be stored in the JWT

### DIFF
--- a/examples/example.go
+++ b/examples/example.go
@@ -26,7 +26,11 @@ func main() {
 	a.Register(&u, "password")
 
 	// Login as user
-	token, err := a.GetToken(u.Email, "password", auth.PERMISSIONS_USER)
+	opts := &auth.GetTokenOpts{
+		RequestedPermissions: auth.PERMISSIONS_USER,
+		Data:                 auth.TokenData{"a": "1"},
+	}
+	token, err := a.GetToken(u.Email, "password", opts)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
This closes #10 by allowing users to supply a `TokenData` `[string]string` map that will be embedded into the JWT on a `GetToken` call. The decrypted and parsed TokenData is available in the `*Claims` struct that the user gets back from a call to `Validate`.

In the future, it may make sense to allow the TokenData to map `[string]interface{}` but for now it's simpler and more opinionated to force the caller to serialize to a string.